### PR TITLE
Change info url

### DIFF
--- a/MacMiner/autoConfigViewViewController.m
+++ b/MacMiner/autoConfigViewViewController.m
@@ -473,7 +473,7 @@ ltcFilePath = nil;
 
 - (IBAction)setupDisplayHelp:(id)sender
 {
-    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"http://fabulouspanda.co.uk/macminer/docs/"]];
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://github.com/fabulouspanda/MacMiner/wiki"]];
 }
 
 - (IBAction)autoConfigToggled:(id)sender {


### PR DESCRIPTION
/docs not available on website.
Using the github wiki may also promote
community documentation moving forward.